### PR TITLE
remove changes to coverage file

### DIFF
--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -8,12 +8,7 @@ echo "mode: atomic" > coverage.txt
 
 for d in $(find ./* -maxdepth 10 -type d); do
     if ls $d/*.go &> /dev/null; then
-        go test  -coverprofile=profile.out -covermode=atomic $d
-        if [ -f profile.out ]; then
-            echo "$(pwd)"
-            cat profile.out | grep -v "mode: " >> coverage.txt
-            rm profile.out
-        fi
+        go test -covermode=atomic $d
     fi
 done
 


### PR DESCRIPTION
We can recognize the default output of `go test` when coverage is enabled. I'm not sure if there was a specific purpose behind the lines changed.

Checkout the [codecov/example-go at .travis.yml](https://github.com/codecov/example-go/blob/master/.travis.yml)
